### PR TITLE
Rigid Bodies function for OptiTrack

### DIFF
--- a/include/libmotioncapture/optitrack.h
+++ b/include/libmotioncapture/optitrack.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "libmotioncapture/motioncapture.h"
+#include "NatNetLinux/NatNet.h"
 
 namespace libmotioncapture {
   class MotionCaptureOptitrackImpl;
@@ -17,11 +18,12 @@ namespace libmotioncapture {
     virtual void waitForNextFrame();
     virtual void getObjects(
       std::vector<Object>& result) const;
-    //virtual void getObjectByName(const std::string & name, Object & result) const;
+    virtual void getObjectByRigidbody(
+      const RigidBody& rb,
+      Object& result) const;
 
     virtual void getPointCloud(
       pcl::PointCloud<pcl::PointXYZ>::Ptr result) const;
-
     virtual void getLatency(
       std::vector<LatencyInfo>& result) const;
 

--- a/src/optitrack.cpp
+++ b/src/optitrack.cpp
@@ -2,6 +2,7 @@
 
 //NatNet
 #include <NatNetLinux/NatNetClient.h>
+#include "NatNetLinux/NatNet.h"
 
 namespace libmotioncapture {
 
@@ -36,61 +37,55 @@ namespace libmotioncapture {
   }
 
   void MotionCaptureOptitrack::getObjects(
-    std::vector<libmotioncapture::Object> & result) const
+    std::vector<Object> & result) const
   {
-      result.clear();
-/*
-      size_t count = 0;
-      if(pImpl->client.isNewFrameReady()){
-          std::vector<RigidBody> const & rBodies = pImpl->client.getLastFrame().rigidBodies();
-          count = rBodies.size();
-          result.resize(count);
-          for(size_t i=0;i<count;++i){
-              getObjectByRigidbody(rBodies[i],result[i]);
-          }
-      }
-*/
-  }
-
-
-/*
-  void MotionCaptureOptitrack::getObjectByRigidbody(const RigidBody & rb, libmotioncapture::Object & result) const{
-
-      std::stringstream sstr;
-      sstr<<rb.id();
-      const std::string name = sstr.str();
-
-      auto const translation = rb.location();
-      auto const quaternion = rb.orientation();
-      if(rb.trackingValid()){
-          Eigen::Vector3f position(translation.x/1000.0,
-                                   translation.y/1000.0,
-                                   translation.z/1000.0);
-
-          Eigen::Quaternionf rotation(quaternion.qw,
-                                      quaternion.qx,
-                                      quaternion.qy,
-                                      quaternion.qz);
-
-          result = Object(name, position, rotation);
-      }else{
-          result = Object(name);
-      }
-
-  }
-*/
-  /*
-  void MotionCaptureOptitrack::getObjectByName(const std::string & name, libmotioncapture::Object & result) const{
+    result.clear();
+    size_t count = 0;
+    
+    if(pImpl->client.isNewFrameReady())
+    {
       std::vector<RigidBody> const & rBodies = pImpl->client.getLastFrame().rigidBodies();
-      for(size_t i=0;i<rBodies.size();++i){
-          std::stringstream sstr;
-          sstr<<rBodies[i].id();
-          const std::string ni = sstr.str();
-          if(ni==name){
-              //getObjectByRigidbody(rBodies[i],result);
-          }
+      count = rBodies.size();
+      result.resize(count);
+  
+      for (size_t i = 0; i < count; ++i) {
+        getObjectByRigidbody(rBodies[i], result[i]);
       }
-  }*/
+    }
+  }
+
+  void MotionCaptureOptitrack::getObjectByRigidbody(
+    const RigidBody& rb,
+    Object& result) const
+  {
+    std::stringstream sstr;
+    sstr << rb.id();
+    const std::string name_number = sstr.str();
+    std::string name_cf = "cf";
+    const std::string name = name_cf + name_number;
+    
+    auto const translation = rb.location();
+    auto const quaternion = rb.orientation();      
+
+    if(rb.trackingValid()) {
+        Eigen::Vector3f position(
+          -translation.y,     
+          translation.x,
+          translation.z);
+        
+        Eigen::Quaternionf rotation(
+          quaternion.qw,
+          -quaternion.qy,
+          quaternion.qx,
+          quaternion.qz
+          );
+
+        result = Object(name, position, rotation);          
+
+    } else {
+        result = Object(name);
+    }
+  } 
 
   void MotionCaptureOptitrack::getPointCloud(
     pcl::PointCloud<pcl::PointXYZ>::Ptr result) const


### PR DESCRIPTION
Fixed rigid body fucntion for OptiTrack.
Now, `object_tracking_type` can be selected to `motionCapture` for tracking 'Rigid Body' in Motive Tracker software.

1. To make flights with rigid body function, create rigid bodies in Motive Tracker software by following the figure.

![set_rigid_body](https://user-images.githubusercontent.com/13003647/38588189-9305ab02-3cf2-11e8-9d11-e35c8ad74060.png)

- Rigid Bodies must be created in order of cf2's ID number in `allCrazyflies.yaml` file.
That is, cf1 must be created as the first one, and cf2 as the second one and cf3...
- A name of rigid body is not important. You can name it as what you want. However, its order is important!

2. Next, in Streaming section, select `True` in `Stream Rigid Bodies` option as shown in the following figure.

![streaming](https://user-images.githubusercontent.com/13003647/38588202-a13258e2-3cf2-11e8-9882-48fa4e113d56.png)

3. Run `~$ roslaunch crazyswarm hover_swarm.launch`

You can see the test flight in [https://youtu.be/LZrXHaepdVE](https://youtu.be/LZrXHaepdVE)
and
[https://youtu.be/Dt3UPIkZKy8](https://youtu.be/Dt3UPIkZKy8)


Thank you.