### PR TITLE
fixed latency unit (milliseconds)

### DIFF
--- a/src/optitrack.cpp
+++ b/src/optitrack.cpp
@@ -110,7 +110,7 @@ namespace libmotioncapture {
     result.clear();
     std::string nn = "";
     double dd = pImpl->client.getLastFrame().latency();
-    result.emplace_back(libmotioncapture::LatencyInfo(nn, dd));
+    result.emplace_back(libmotioncapture::LatencyInfo(nn, dd/1000));
   }
 
   MotionCaptureOptitrack::~MotionCaptureOptitrack()


### PR DESCRIPTION
fixed latency unit (milliseconds).

Since rigidBody.occluded() in `crazyswarm_server.cpp` line 890 has value "1" not "0" sometimes, `ROS_WARN("No updated pose for motion capture object %s", name.c_str())` (line 921 in the same file) is displayed.
It is not critical to fly cf2, but I am not sure why it happened.
I think it needs to be discussed with optitrack company.