### PR TITLE
Fix rigidbody mocap parsing

### DIFF
--- a/src/optitrack.cpp
+++ b/src/optitrack.cpp
@@ -354,7 +354,11 @@ namespace libmotioncapture {
         for (int i=0; i < nMarkerSets; i++)
         {
           ptr += strlen(ptr) + 1;
-          ptr += (*ptr * 12) + 4;
+          int nMarkers = 0; memcpy(&nMarkers, ptr, 4); ptr += 4;
+          for(int j=0; j < nMarkers; j++)
+          {
+            ptr += 12;
+          }
         }
 
         // Loop through unlabeled markers

--- a/src/optitrack.cpp
+++ b/src/optitrack.cpp
@@ -355,10 +355,7 @@ namespace libmotioncapture {
         {
           ptr += strlen(ptr) + 1;
           int nMarkers = 0; memcpy(&nMarkers, ptr, 4); ptr += 4;
-          for(int j=0; j < nMarkers; j++)
-          {
-            ptr += 12;
-          }
+          ptr += nMarkers * 12;
         }
 
         // Loop through unlabeled markers

--- a/src/optitrack.cpp
+++ b/src/optitrack.cpp
@@ -354,7 +354,7 @@ namespace libmotioncapture {
         for (int i=0; i < nMarkerSets; i++)
         {
           ptr += strlen(ptr) + 1;
-          ptr += 12;
+          ptr += (*ptr * 12) + 4;
         }
 
         // Loop through unlabeled markers


### PR DESCRIPTION
I believe optitrack.cpp was derived from https://github.com/whoenig/NatNetSDKCrossplatform/blob/master/src/PacketClient.cpp this request resolves an incorrect simplification of  line 661 through line 670

This resolves:
#6 
https://github.com/USC-ACTLab/crazyswarm/issues/364
possibly others

Tested on:
Ubuntu 18.04
Motive 2.2.0
NatNetVersion: 14.140.50.0
ServerVersion: 3.1.0.0